### PR TITLE
fix: ENCRYPTION_KEY validation, PR review fixes, debug logging

### DIFF
--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -10,7 +10,11 @@ const TAG_LENGTH = 16;
 const TAG_POSITION = SALT_LENGTH + IV_LENGTH;
 const ENCRYPTED_POSITION = TAG_POSITION + TAG_LENGTH;
 
+let cachedEncryptionKey: string | undefined;
+
 function getEncryptionKey(): string {
+  if (cachedEncryptionKey) return cachedEncryptionKey;
+
   const key = process.env.ENCRYPTION_KEY;
   if (!key || key.length < 16) {
     throw new Error(
@@ -18,10 +22,9 @@ function getEncryptionKey(): string {
       'Generate one with: openssl rand -base64 48'
     );
   }
+  cachedEncryptionKey = key;
   return key;
 }
-
-const ENCRYPTION_KEY = getEncryptionKey();
 
 /**
  * Encrypt sensitive data using AES-256-GCM
@@ -34,7 +37,7 @@ export async function encrypt(plaintext: string): Promise<string> {
   const iv = crypto.randomBytes(IV_LENGTH);
   const salt = crypto.randomBytes(SALT_LENGTH);
   const key = await pbkdf2(
-    ENCRYPTION_KEY,
+    getEncryptionKey(),
     salt,
     100000,
     32,
@@ -78,7 +81,7 @@ export async function decrypt(ciphertext: string): Promise<string> {
 
   // Derive key using the same salt
   const key = await pbkdf2(
-    ENCRYPTION_KEY,
+    getEncryptionKey(),
     salt,
     100000,
     32,

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -10,6 +10,19 @@ const TAG_LENGTH = 16;
 const TAG_POSITION = SALT_LENGTH + IV_LENGTH;
 const ENCRYPTED_POSITION = TAG_POSITION + TAG_LENGTH;
 
+function getEncryptionKey(): string {
+  const key = process.env.ENCRYPTION_KEY;
+  if (!key || key.length < 16) {
+    throw new Error(
+      'ENCRYPTION_KEY environment variable is missing or too short (minimum 16 characters). ' +
+      'Generate one with: openssl rand -base64 48'
+    );
+  }
+  return key;
+}
+
+const ENCRYPTION_KEY = getEncryptionKey();
+
 /**
  * Encrypt sensitive data using AES-256-GCM
  * @param plaintext - The data to encrypt
@@ -21,7 +34,7 @@ export async function encrypt(plaintext: string): Promise<string> {
   const iv = crypto.randomBytes(IV_LENGTH);
   const salt = crypto.randomBytes(SALT_LENGTH);
   const key = await pbkdf2(
-    process.env.ENCRYPTION_KEY!,
+    ENCRYPTION_KEY,
     salt,
     100000,
     32,
@@ -65,7 +78,7 @@ export async function decrypt(ciphertext: string): Promise<string> {
 
   // Derive key using the same salt
   const key = await pbkdf2(
-    process.env.ENCRYPTION_KEY!,
+    ENCRYPTION_KEY,
     salt,
     100000,
     32,


### PR DESCRIPTION
## Summary

- **Fix #40**: Add lazy runtime validation for `ENCRYPTION_KEY` — throws a clear error message with setup instructions instead of a cryptic `ERR_CRYPTO_INVALID_KEYLEN` crash. Reverted the previous zod build-time approach that broke Next.js static analysis.
- **Fix #41**: Closed as not applicable — `/api/logs/route.ts` does not exist in the codebase.
- Address PR review: remove debug logs, fix pagination NaN, unblock bulk delete
- Remove dead code in `gmail/client.ts`
- Fix `LOG_LEVEL=DEBUG` ignored due to falsy `0` value
- Add detailed debug logging for scan pipeline
- Refactor: remove BullMQ/Redis queues, analytics, fix pagination bugs
- Fix security tokens, pagination, and deployment docs

## Closes

Closes #40

## Deferred (not resolved)

- **#41** / **#61**: Closed as not applicable — logs API does not exist
- **#43**: Already closed — full scan bound is optional via `MAX_FULL_SCAN_LIMIT`