### PR TITLE
fix: make lastSyncAt nullable to fix first-scan detection (#76)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,7 +106,7 @@ model GmailSyncState {
   userId          String    @unique
   historyId       BigInt?
   watchExpiration DateTime?
-  lastSyncAt      DateTime  @default(now())
+  lastSyncAt      DateTime?
   scanStatus      String    @default("idle")
   scanProgress    Int?
   scanTotal       Int?


### PR DESCRIPTION
## Summary
- Made `GmailSyncState.lastSyncAt` nullable by removing `@default(now())` in the Prisma schema
- This fixes the first-scan detection bug where `!syncState.lastSyncAt` always evaluated `false` after a sync reset

## Problem
After `/api/sync/reset` deletes and recreates `GmailSyncState`, the `@default(now())` filled in `lastSyncAt` with the current timestamp. The next scan then incorrectly treated it as an incremental scan instead of a full scan.

## Fix
Removing `@default(now())` means newly created records (including after reset) have `lastSyncAt = null`, which correctly triggers the first-scan code path.

## Test plan
- [x] `prisma generate` succeeds
- [x] `tsc --noEmit` — zero type errors
- [x] `eslint` — zero warnings/errors
- [ ] `prisma db push` — apply to database
- [ ] Manual: sync reset → verify `lastSyncAt` is null → next scan triggers full scan