### PR TITLE
fix: address issues #75, #77, #78

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -70,14 +70,22 @@ done
 if [ -n "$DATABASE_URL" ]; then
     echo "🔄 Running database schema setup..."
     cd /app
-    # Try migrations first, then db push if no migrations exist
-    if npx prisma migrate deploy 2>/dev/null | grep -q "No migration"; then
+    # Try migrations first; fall back to db push only on "no migrations" status
+    migrate_output=$(npx prisma migrate deploy 2>&1)
+    migrate_exit=$?
+    if echo "$migrate_output" | grep -qi "no migration"; then
         echo "📦 No migrations found, applying schema directly..."
         if ! npx prisma db push --skip-generate; then
             echo "❌ Schema setup failed. Please check your database configuration."
             echo "   You may need to run: npx prisma migrate dev --name init"
             exit 1
         fi
+    elif [ $migrate_exit -ne 0 ]; then
+        echo "❌ Prisma migration failed (exit code $migrate_exit):"
+        echo "$migrate_output"
+        exit 1
+    else
+        echo "✅ Migrations applied successfully"
     fi
 fi
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,7 +19,7 @@ const eslintConfig = [
       }],
       "@typescript-eslint/no-explicit-any": "warn",
       "react-hooks/exhaustive-deps": "warn",
-      "no-console": ["warn", { allow: ["warn", "error"] }],
+      "no-console": ["warn", { allow: ["warn", "error", "info", "debug"] }],
     },
   },
 ];

--- a/src/components/subscriptions/subscription-list.tsx
+++ b/src/components/subscriptions/subscription-list.tsx
@@ -79,7 +79,8 @@ export function SubscriptionList({ userId: _userId, initialSubscriptions, onUpda
     senderEmails: string[];
     subscriptionIds?: string[];
     count: number;
-  }>({ open: false, senderEmails: [], count: 0 });
+    totalEmails: number;
+  }>({ open: false, senderEmails: [], count: 0, totalEmails: 0 });
 
   // Pagination state
   const [hasMore, setHasMore] = useState(false);
@@ -300,6 +301,7 @@ export function SubscriptionList({ userId: _userId, initialSubscriptions, onUpda
         senderEmails: selectedSubs.map((s) => s.senderEmail),
         subscriptionIds: Array.from(selectedIds),
         count: selectedSubs.length,
+        totalEmails: selectedSubs.reduce((sum, s) => sum + s.messageCount, 0),
       });
       return;
     }
@@ -321,10 +323,12 @@ export function SubscriptionList({ userId: _userId, initialSubscriptions, onUpda
   };
 
   const deleteFromSender = async (senderEmail: string, _senderName: string) => {
+    const sub = subscriptions.find((s) => s.senderEmail === senderEmail);
     setDeleteConfirm({
       open: true,
       senderEmails: [senderEmail],
       count: 1,
+      totalEmails: sub?.messageCount ?? 0,
     });
   };
 
@@ -349,7 +353,7 @@ export function SubscriptionList({ userId: _userId, initialSubscriptions, onUpda
 
       if (response.ok) {
         // Close dialog and clear selection
-        setDeleteConfirm({ open: false, senderEmails: [], count: 0 });
+        setDeleteConfirm({ open: false, senderEmails: [], count: 0, totalEmails: 0 });
         setSelectedIds(new Set());
 
         // Rescan each affected sender to update counts or remove if deleted
@@ -859,15 +863,26 @@ export function SubscriptionList({ userId: _userId, initialSubscriptions, onUpda
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-destructive" />
-              Delete All Emails?
+              Move Emails to Trash?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              This will permanently delete all emails from {deleteConfirm.count === 1
-                ? `"${deleteConfirm.senderEmails[0]}"`
-                : `${deleteConfirm.count} senders`
+              This will move <strong>{deleteConfirm.totalEmails.toLocaleString()} email{deleteConfirm.totalEmails !== 1 ? 's' : ''}</strong> to Trash from {deleteConfirm.count === 1
+                ? (
+                  <span className="font-medium">&ldquo;{deleteConfirm.senderEmails[0]}&rdquo;</span>
+                )
+                : (
+                  <>
+                    {deleteConfirm.count} senders:
+                    <span className="block mt-1 max-h-24 overflow-y-auto text-xs font-mono">
+                      {deleteConfirm.senderEmails.join(', ')}
+                    </span>
+                  </>
+                )
               }.
               <br /><br />
-              <strong className="text-destructive">This action cannot be undone.</strong>
+              Deleted emails can be recovered from Gmail&apos;s Trash for up to 30 days.
+              <br /><br />
+              <strong className="text-destructive">This action cannot be undone through Prunebox.</strong>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -876,7 +891,7 @@ export function SubscriptionList({ userId: _userId, initialSubscriptions, onUpda
               onClick={confirmDelete}
               className="bg-destructive hover:bg-destructive/90"
             >
-              Delete All Emails
+              Move to Trash
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -82,12 +82,13 @@ class Logger {
 
     const formattedMessage = this.formatMessage(entry);
 
-    // Use appropriate console method (only warn/error allowed by ESLint)
+    // Use appropriate console method
     switch (level) {
       case LogLevel.DEBUG:
+        console.debug(formattedMessage);
+        break;
       case LogLevel.INFO:
-        // Use console.warn for info/debug since console.info/debug are not allowed
-        console.warn(formattedMessage);
+        console.info(formattedMessage);
         break;
       case LogLevel.WARN:
         console.warn(formattedMessage);

--- a/src/modules/queues/jobs.ts
+++ b/src/modules/queues/jobs.ts
@@ -429,6 +429,13 @@ export async function runUnsubscribe(data: UnsubscribeJobData) {
 export async function runBulkDelete(data: BulkDeleteJobData) {
   const { userId, senderEmail } = data;
 
+  // Dry-run mode: log what would happen without calling the Gmail API
+  if (process.env.NODE_ENV === 'development') {
+    logger.info(`[DRY RUN] Would delete emails from ${senderEmail} for user ${userId}`);
+    logger.info(`[DRY RUN] Search patterns: from:${senderEmail}, from:${senderEmail.includes('@') ? senderEmail.split('@')[1] : senderEmail}`);
+    return { success: true, deletedCount: 0, dryRun: true };
+  }
+
   logger.info(`Starting bulk delete for ${senderEmail}`);
 
   try {


### PR DESCRIPTION
## Summary

- **#75** — `docker/entrypoint.sh` now captures `prisma migrate deploy` output and checks exit codes explicitly instead of discarding stderr. Migration failures now exit the container with a clear error message.
- **#77** — `src/lib/logger.ts` now routes `DEBUG` → `console.debug()` and `INFO` → `console.info()` instead of both going through `console.warn()`. ESLint config updated to allow `info` and `debug` console methods.
- **#78** — Bulk delete dialog enhanced with email count, sender email list, and accurate 30-day trash recovery text. Added development dry-run safeguard in `jobs.ts` that skips the Gmail API call.

## Test plan

- [ ] Verify `docker/entrypoint.sh` handles migration success, "no migration" fallback, and migration failure correctly
- [ ] Confirm logger outputs appear in browser DevTools at the correct level (Info/Debug tabs)
- [ ] Test bulk delete dialog shows email count, sender list, and recovery text
- [ ] Confirm dev dry-run returns `{ success: true, deletedCount: 0, dryRun: true }` in development
- [ ] Confirm production bulk delete is unaffected (no dry-run guard)